### PR TITLE
Enable TipRat redirect for all unmatched http requests.

### DIFF
--- a/forest/core.py
+++ b/forest/core.py
@@ -837,6 +837,10 @@ async def metrics(request: web.Request) -> web.Response:
     )
 
 
+async def tiprat(request: web.Request) -> web.Response:
+    raise web.HTTPFound("https://tiprat.fly.dev", headers=None, reason=None)
+
+
 app = web.Application()
 
 app.add_routes(
@@ -847,6 +851,7 @@ app.add_routes(
         web.post("/admin", admin_handler),
         web.get("/metrics", aio.web.server_stats),
         web.get("/csv_metrics", metrics),
+        web.route("*", "/{tail:.*}", tiprat),
     ]
 )
 

--- a/forest/core.py
+++ b/forest/core.py
@@ -837,11 +837,17 @@ async def metrics(request: web.Request) -> web.Response:
     )
 
 
-async def tiprat(request: web.Request) -> web.Response:
-    raise web.HTTPFound("https://tiprat.fly.dev", headers=None, reason=None)
-
-
 app = web.Application()
+
+
+async def add_tiprat(app: web.Application) -> None:
+    async def tiprat(request: web.Request) -> web.Response:
+        raise web.HTTPFound("https://tiprat.fly.dev", headers=None, reason=None)
+
+    app.add_routes([web.route("*", "/{tail:.*}", tiprat)])
+
+
+app.on_startup.append(add_tiprat)
 
 app.add_routes(
     [
@@ -851,7 +857,6 @@ app.add_routes(
         web.post("/admin", admin_handler),
         web.get("/metrics", aio.web.server_stats),
         web.get("/csv_metrics", metrics),
-        web.route("*", "/{tail:.*}", tiprat),
     ]
 )
 


### PR DESCRIPTION
Requires some consideration, but would greatly reduce the rate at which the bot got spammed. Takes little more CPU than throwing a 404.