### PR TITLE
improve error correction and put behind ENABLE_MAGIC feature gate

### DIFF
--- a/forest/core.py
+++ b/forest/core.py
@@ -673,8 +673,8 @@ class Bot(Signal):
         # bail on the easy path
         if maybe_command and hasattr(self, "do_" + maybe_command):
             return await getattr(self, "do_" + maybe_command)(message)
-        # if we didn't match...
-        if maybe_command:
+        # if we didn't match and magic is enabled...
+        if maybe_command and utils.get_secret("ENABLE_MAGIC"):
             # get the closest command
             score, cmd = self.match_command(maybe_command)
             if score < int(utils.get_secret("TYPO_THRESHOLD") or 3):

--- a/forest/core.py
+++ b/forest/core.py
@@ -66,10 +66,70 @@ def fmt_ms(ts: int) -> str:
     return datetime.datetime.utcfromtimestamp(ts / 1000).isoformat()
 
 
-def jaccard(s1: str, s2: str) -> float:
-    intersection = len(list(set(s1).intersection(s2)))
-    union = (len(s1) + len(s2)) - intersection
-    return float(intersection) / union
+def levenshtein_norm(source: str, target: str) -> float:
+    """Calculates the normalized Levenshtein distance between two string
+    arguments. The result will be a float in the range [0.0, 1.0], with 1.0
+    signifying the biggest possible distance between strings with these lengths
+    """
+
+    # Compute Levenshtein distance using helper function. The max is always
+    # just the length of the longer string, so this is used to normalize result
+    # before returning it
+    distance = levenshtein(source, target)
+    return float(distance) / max(len(source), len(target))
+
+
+def levenshtein(source: str, target: str) -> int:
+    """Computes the Levenshtein
+    (https://en.wikipedia.org/wiki/Levenshtein_distance)
+    and restricted Damerau-Levenshtein
+    (https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance)
+    distances between two Unicode strings with given lengths using the
+    Wagner-Fischer algorithm
+    (https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).
+    These distances are defined recursively, since the distance between two
+    strings is just the cost of adjusting the last one or two characters plus
+    the distance between the prefixes that exclude these characters (e.g. the
+    distance between "tester" and "tested" is 1 + the distance between "teste"
+    and "teste"). The Wagner-Fischer algorithm retains this idea but eliminates
+    redundant computations by storing the distances between various prefixes in
+    a matrix that is filled in iteratively.
+    """
+
+    # Create matrix of correct size (this is s_len + 1 * t_len + 1 so that the
+    # empty prefixes "" can also be included). The leftmost column represents
+    # transforming various source prefixes into an empty string, which can
+    # always be done by deleting all characters in the respective prefix, and
+    # the top row represents transforming the empty string into various target
+    # prefixes, which can always be done by inserting every character in the
+    # respective prefix. The ternary used to build the list should ensure that
+    # this row and column are now filled correctly
+    s_range = range(len(source) + 1)
+    t_range = range(len(target) + 1)
+    matrix = [[(i if j == 0 else j) for j in t_range] for i in s_range]
+
+    # Iterate through rest of matrix, filling it in with Levenshtein
+    # distances for the remaining prefix combinations
+    for i in s_range[1:]:
+        for j in t_range[1:]:
+            # Applies the recursive logic outlined above using the values
+            # stored in the matrix so far. The options for the last pair of
+            # characters are deletion, insertion, and substitution, which
+            # amount to dropping the source character, the target character,
+            # or both and then calculating the distance for the resulting
+            # prefix combo. If the characters at this point are the same, the
+            # situation can be thought of as a free substitution
+            del_dist = matrix[i - 1][j] + 1
+            ins_dist = matrix[i][j - 1] + 1
+            sub_trans_cost = 0 if source[i - 1] == target[j - 1] else 1
+            sub_dist = matrix[i - 1][j - 1] + sub_trans_cost
+
+            # Choose option that produces smallest distance
+            matrix[i][j] = min(del_dist, ins_dist, sub_dist)
+
+    # At this point, the matrix is full, and the biggest prefixes are just the
+    # strings themselves, so this is the desired distance
+    return matrix[len(source)][len(target)]
 
 
 class Signal:
@@ -603,18 +663,23 @@ class Bot(Signal):
     # list_que, status_list; dark, synthwav, synthese, "fantasy,"; bing
     # could you embedify these instead of recalculating string distance? or cache
     def match_command(self, inp: str) -> tuple[float, str]:
-        return sorted(((jaccard(inp, cmd), cmd) for cmd in self.commands))[-1]
+        return sorted(((levenshtein(inp, cmd), cmd) for cmd in self.commands))[0]
 
     async def handle_message(self, message: Message) -> Response:
         """Method dispatch to do_x commands and goodies.
         Overwrite this to add your own non-command logic,
         but call super().handle_message(message) at the end"""
-        if message.arg0:
-            if hasattr(self, "do_" + message.arg0):
-                return await getattr(self, "do_" + message.arg0)(message)
-            score, cmd = self.match_command(message.arg0)
-            if score > float(utils.get_secret("TYPO_THRESHOLD") or 0.7):
-                return await getattr(self, "do_" + cmd)(message)
+        maybe_command = message.command if message.group else message.arg0
+        # bail on the easy path
+        if maybe_command and hasattr(self, "do_" + maybe_command):
+            return await getattr(self, "do_" + maybe_command)(message)
+        # if we didn't match...
+        if maybe_command:
+            # get the closest command
+            score, cmd = self.match_command(maybe_command)
+            if score < int(utils.get_secret("TYPO_THRESHOLD") or 3):
+                # invoke the function and return the response
+                return await getattr(self, f"do_{cmd}")(message)
             expansions = [cmd for cmd in self.commands if cmd.startswith(message.arg0)]
             if len(expansions) == 1:
                 return await getattr(self, "do_" + expansions[0])(message)
@@ -689,9 +754,7 @@ class Bot(Signal):
             return await eval(f"{fn_name}()", env)  # pylint: disable=eval-used
 
         if msg.full_text and len(msg.tokens) > 1:
-            source_blob = (
-                msg.full_text.replace("eval", "", 1).replace("Eval", "", 1).lstrip("/ ")
-            )
+            source_blob = msg.full_text.replace(msg.arg0, "", 1).lstrip("/ ")
             return str(await async_exec(source_blob, locals()))
         return None
 


### PR DESCRIPTION
This replaces Jaccard distance with Levenshtein distance error correction. 
The default match is delta-3, sufficient to match hp -> help, and all of: imagin, imogen, imagen, image, imagines, imahine -> 'imagine'

Require the / in groups to activate error correction.

Fix eval to work with expansion