### PR TITLE
Use ULIDs for JSON RPC

### DIFF
--- a/.github/Pipfile
+++ b/.github/Pipfile
@@ -23,6 +23,7 @@ protobuf = "*"
 types-termcolor = "*"
 types-protobuf = "*"
 pyqrcode = "*"
+ulid2 = "*"
 
 [packages.aiohttp]
 extras = [ "speedups",]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.local/share/virtualenvs
-          key: '${{ runner.os }}-pipenv-v5-${{ hashFiles(''**/Pipfile.lock'') }}'
+          key: '${{ runner.os }}-pipenv-v6-${{ hashFiles(''**/Pipfile.lock'') }}'
       - name: Install dependencies
         if: steps.cache-pipenv.outputs.cache-hit != 'true'
         run: cp .github/Pipfile .; pipenv install --skip-lock --pre


### PR DESCRIPTION
Supersedes #86 . Shorter, more legible, and lexicographical sortable! Yay kind tools.