### PR TITLE
Prevent transaction receipts from being sent if transaction submission errors out

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.local/share/virtualenvs
-          key: '${{ runner.os }}-pipenv-v7-${{ hashFiles(''**/Pipfile.lock'') }}'
+          key: '${{ runner.os }}-pipenv-v8-${{ hashFiles(''**/Pipfile.lock'') }}'
       - name: Install dependencies
         if: steps.cache-pipenv.outputs.cache-hit != 'true'
         run: cp .github/Pipfile .; pipenv install --skip-lock --pre


### PR DESCRIPTION
* Adds a check to ensure that full service has sent back a "result" (i.e. a healthy jsonrpc status) from the submit_transaction method before creating a receipt
* If submit_transaction fails it puts error information into the response, exists prior to creating/sending receipts, and sends this information back to the transaction sender so it can be handled properly