### PR TITLE
Pdictng fixes from Hotline porting efforts

### DIFF
--- a/forest/pdictng.py
+++ b/forest/pdictng.py
@@ -230,6 +230,11 @@ class aPersistDict:
         async with self.rwlock:
             return self.dict_.get(key, default)
 
+    async def keys(self) -> List[str]:
+        async with self.rwlock:
+            return self.dict_.keys()
+
+
     async def set(self, key: str, value: Any) -> Any:
         """Sets a value at a given key, returns metadata."""
         async with self.rwlock:

--- a/forest/pdictng.py
+++ b/forest/pdictng.py
@@ -8,7 +8,6 @@ import hashlib
 import json
 import os
 import time
-import logging
 from typing import Union, Any, Optional, cast, List
 
 import aiohttp

--- a/forest/pdictng.py
+++ b/forest/pdictng.py
@@ -19,10 +19,13 @@ SALT = os.getenv("SALT", "ECmG8HtNNMWb4o2bzyMqCmPA6KTYJPCkd")
 # build your AESKEY envvar with this: cat /dev/urandom | head -c 32 | base58
 AESKEY = base58.b58decode(os.getenv("AESKEY", "kWKuomB9Ty3GcJ9yA1yED").encode()) * 2
 
-if not AESKEY or len(AESKEY) not in [16, 32]:
+if not AESKEY or len(AESKEY) not in [16, 32, 64]:
     raise ValueError(
         "Need to set 128b or 256b (16 or 32 byte) AESKEY envvar for persistence. It should be base58 encoded."
     )
+
+if len(AESKEY) == 64:
+    AESKEY = AESKEY[:32]
 
 pAUTH = os.getenv("PAUTH", "")
 
@@ -214,6 +217,7 @@ class aPersistDict:
         self.write_task = asyncio.create_task(self.set(key, value))
 
     async def finish_init(self, **kwargs: Any) -> None:
+        """Does the asynchrnous part of the initialisation process."""
         async with self.rwlock:
             key = f"Persist_{self.tag}_{NAMESPACE}"
             result = await self.client.get(key)
@@ -222,6 +226,7 @@ class aPersistDict:
             self.dict_.update(**kwargs)
 
     async def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
+        """Analogous to dict().get() - but async. Waits until writes have completed on the backend before returning results."""
         # always wait for pending writes - where a task has been created but lock not held
         if self.write_task:
             await self.write_task
@@ -234,11 +239,26 @@ class aPersistDict:
         async with self.rwlock:
             return self.dict_.keys()
 
+    async def remove(self, key: str) -> None:
+        """Removes a value from the map, if it exists."""
+        await self.set(key, None)
+        return None
+
+    async def pop(self, key: str, default: Any = None) -> Any:
+        """Returns and removes a value if it exists"""
+        res = await self.get(key, default)
+        await self.set(key, None)
+        return res
 
     async def set(self, key: str, value: Any) -> Any:
         """Sets a value at a given key, returns metadata."""
         async with self.rwlock:
-            self.dict_.update({key: value})
+            if key and value:
+                self.dict_.update({key: value})
+            elif key and not value and key in self.dict_:
+                self.dict_.pop(key)
+            elif key and key not in self.dict_:
+                return None
             key = f"Persist_{self.tag}_{NAMESPACE}"
             value = json.dumps(self.dict_)
             val = await self.client.post(key, value)

--- a/forest/pdictng.py
+++ b/forest/pdictng.py
@@ -210,11 +210,9 @@ class aPersistDict:
         return f"a{self.dict_}"
 
     async def __getitem__(self, key: str) -> Any:
-        logging.debug("get:" + self.tag)
         return await self.get(key)
 
     def __setitem__(self, key: str, value: Union[float, str]) -> None:
-        logging.debug("setitem:" + self.tag)
         if self.write_task and not self.write_task.done():
             raise ValueError("Can't set value. write_task incomplete.")
         self.write_task = asyncio.create_task(self.set(key, value))
@@ -230,7 +228,6 @@ class aPersistDict:
 
     async def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
         """Analogous to dict().get() - but async. Waits until writes have completed on the backend before returning results."""
-        logging.debug("get:" + self.tag)
         # always wait for pending writes - where a task has been created but lock not held
         if self.write_task:
             await self.write_task
@@ -240,20 +237,17 @@ class aPersistDict:
             return self.dict_.get(key, default)
 
     async def keys(self) -> List[str]:
-        logging.debug("keys:" + self.tag)
         async with self.rwlock:
-            return self.dict_.keys()
+            return list(self.dict_.keys())
 
     async def remove(self, key: str) -> None:
         """Removes a value from the map, if it exists."""
-        logging.debug("remove:" + self.tag)
         await self.set(key, None)
         return None
 
     async def extend(self, key: str, value: str) -> None:
         """Since one cannot simply add to a coroutine, this function exists.
         If the key exists and the value is None, or an empty array, the provided value is added to a(the) list at that value."""
-        logging.debug("extend:" + self.tag)
         value_to_extend = []
         async with self.rwlock:
             value_to_extend = self.dict_.get(key, [])
@@ -262,7 +256,6 @@ class aPersistDict:
 
     async def remove_from(self, key: str, not_value: str) -> None:
         """Removes a value specified from the list, if present."""
-        logging.debug("remove_from:" + self.tag)
         async with self.rwlock:
             values_without_specified = [
                 el for el in self.dict_.get(key, []) if not_value != el
@@ -271,7 +264,6 @@ class aPersistDict:
 
     async def pop(self, key: str, default: Any = None) -> Any:
         """Returns and removes a value if it exists"""
-        logging.debug("pop:" + self.tag)
         res = await self.get(key, default)
         await self.set(key, None)
         return res
@@ -279,10 +271,9 @@ class aPersistDict:
     async def _set(self, key: str, value: Any) -> Any:
         """Sets a value at a given key, returns metadata.
         This function exists so *OTHER FUNCTIONS* holding the lock can set values."""
-        logging.debug("_set:" + self.tag)
-        if key != None and value != None:
+        if key is not None and value is not None:
             self.dict_.update({key: value})
-        elif key and value != None and key in self.dict_:
+        elif key and value is not None and key in self.dict_:
             self.dict_.pop(key)
         key = f"Persist_{self.tag}_{NAMESPACE}"
         value = json.dumps(self.dict_)
@@ -290,6 +281,5 @@ class aPersistDict:
 
     async def set(self, key: str, value: Any) -> Any:
         """Sets a value at a given key, returns metadata."""
-        logging.debug("set:" + self.tag)
         async with self.rwlock:
             return await self._set(key, value)


### PR DESCRIPTION
adds async methods for the following common usage patterns:

>keys, remove_from, extend, pop,

refactor 'set' into  '_set' which does work with lock, allowing an easy async push / upload abstraction for other methods to use