### PR TITLE
Faeries/refactor yesno question

### DIFF
--- a/forest/core.py
+++ b/forest/core.py
@@ -1305,7 +1305,7 @@ class QuestionBot(PayBot):
         answer = await self.ask_freeform_question(
             recipient, question_text, require_first_device
         )
-
+        answer = answer.lower().rstrip(string.punctuation)
         # if there is an answer and it is negative or positive
         if answer and answer.lower() in (AFFIRMATIVE_ANSWERS + NEGATIVE_ANSWERS):
             # return true if it's in affirmative answers otherwise assume it was negative and return false

--- a/forest/core.py
+++ b/forest/core.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import signal
+import string
 import sys
 import time
 import traceback
@@ -1307,14 +1308,14 @@ class QuestionBot(PayBot):
         )
         answer = answer.lower().rstrip(string.punctuation)
         # if there is an answer and it is negative or positive
-        if answer and answer.lower() in (AFFIRMATIVE_ANSWERS + NEGATIVE_ANSWERS):
+        if answer and answer in (AFFIRMATIVE_ANSWERS + NEGATIVE_ANSWERS):
             # return true if it's in affirmative answers otherwise assume it was negative and return false
-            if answer.lower() in AFFIRMATIVE_ANSWERS:
+            if answer in AFFIRMATIVE_ANSWERS:
                 return True
             return False
 
         # return none if user answers cancel, etc
-        if answer and answer.lower() in self.TERMINAL_ANSWERS:
+        if answer and answer in self.TERMINAL_ANSWERS:
             return None
 
         # if the answer is not a terminal answer but also not a match, add clarifier and ask again

--- a/forest/core.py
+++ b/forest/core.py
@@ -1298,15 +1298,17 @@ class QuestionBot(PayBot):
         """Asks a question that expects a yes or no answer. Returns a Boolean:
         True if Yes False if No. None if cancelled"""
         # First define what we consider negative or affirmative answers
-        AFFIRMATIVE_ANSWERS = ["yes","yeah","y","yup","affirmative"]
-        NEGATIVE_ANSWERS = ["no","nope","n","negatory", "nuh-uh"]
+        AFFIRMATIVE_ANSWERS = ["yes", "yeah", "y", "yup", "affirmative"]
+        NEGATIVE_ANSWERS = ["no", "nope", "n", "negatory", "nuh-uh"]
 
         # ask the question as a freeform question
-        answer = await self.ask_freeform_question(recipient,question_text,require_first_device)
-        
-        #if there is an answer and it is negative or positive
+        answer = await self.ask_freeform_question(
+            recipient, question_text, require_first_device
+        )
+
+        # if there is an answer and it is negative or positive
         if answer and answer.lower() in (AFFIRMATIVE_ANSWERS + NEGATIVE_ANSWERS):
-            #return true if it's in affirmative answers otherwise assume it was negative and return false
+            # return true if it's in affirmative answers otherwise assume it was negative and return false
             if answer.lower() in AFFIRMATIVE_ANSWERS:
                 return True
             return False
@@ -1315,12 +1317,13 @@ class QuestionBot(PayBot):
         if answer and answer.lower() in self.TERMINAL_ANSWERS:
             return None
 
-        #if the answer is not a terminal answer but also not a match, add clarifier and ask again
+        # if the answer is not a terminal answer but also not a match, add clarifier and ask again
         if "Please answer yes or no" not in question_text:
             question_text = "Please answer yes or no, or cancel:\n \n" + question_text
-        
-        return await self.ask_yesno_question(recipient,question_text,require_first_device)
 
+        return await self.ask_yesno_question(
+            recipient, question_text, require_first_device
+        )
 
     async def ask_address_question(
         self,

--- a/hotline/hotline.py
+++ b/hotline/hotline.py
@@ -958,12 +958,6 @@ class ClanGat(TalkBack):
             return None
         if code == "?":
             return await self.do_help(msg)
-        if code == "y":
-            return await self.do_yes(msg)
-        if code == "n":
-            return await self.do_no(msg)
-        if code and code.rstrip(string.punctuation) == "yes":  # yes!
-            return await self.do_yes(msg)
         if code in "+ buy purchase".split():  # was a function, now helptext
             return self.PAYMENTS_HELPTEXT
         if not code:

--- a/mobfriend/mobfriend.py
+++ b/mobfriend/mobfriend.py
@@ -501,10 +501,6 @@ https://support.signal.org/hc/en-us/articles/360057625692-In-app-Payments"""
             return await self.do_payments(msg)
         if code == "?":
             code = msg.arg0 = "help"
-        elif code == "y":
-            return await self.do_yes(msg)
-        elif code == "n":
-            return await self.do_no(msg)
         elif code == "help" and msg.arg1:
             try:
                 doc = getattr(self, f"do_{msg.arg1}").__doc__

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -51,6 +51,7 @@ class MockMessage(Message):
 
     def __init__(self, text: str) -> None:
         self.text = text
+        self.full_text = text
         self.source = USER_NUMBER
         self.uuid = "cf3d7d34-2dcd-4fcd-b193-cbc6a666758b"
         self.mentions = []

--- a/tests/testbots/test_questions_bot.py
+++ b/tests/testbots/test_questions_bot.py
@@ -122,6 +122,22 @@ class TestBot(QuestionBot):
             return choice
         return "oops, sorry"
 
+    async def do_test_multiple_choice_dict_raise(self, message: Message) -> Response:
+        """Asks a Sample Multiple Choice question with duplicate entries when not lowercased"""
+
+        question_text = "What is your tshirt size?"
+        options = {"S": "", "M": "M", "L": "", "XL": "", "xl": ""}
+
+        try:
+            choice = await self.ask_multiple_choice_question(
+                message.source, question_text, options, require_confirmation=True
+            )
+            if choice:
+                return choice
+            return "oops, sorry"
+        except ValueError:
+            return "You know what you did"
+
     async def do_test_address_question_no_confirmation(
         self, message: Message
     ) -> Response:

--- a/tests/testbots/test_questions_bot.py
+++ b/tests/testbots/test_questions_bot.py
@@ -9,7 +9,12 @@ class TestBot(QuestionBot):
     async def do_test_ask_yesno_question(self, message: Message) -> Response:
         """Asks a sample Yes or No question"""
 
-        if await self.ask_yesno_question(message.source, "Do you like faeries?"):
+        answer = await self.ask_yesno_question(message.source, "Do you like faeries?")
+        
+        if answer is None:
+            return "oops, sorry"
+
+        if answer:
             return "That's cool, me too!"
         return "Aww :c"
 

--- a/tests/testbots/test_questions_bot.py
+++ b/tests/testbots/test_questions_bot.py
@@ -10,7 +10,7 @@ class TestBot(QuestionBot):
         """Asks a sample Yes or No question"""
 
         answer = await self.ask_yesno_question(message.source, "Do you like faeries?")
-        
+
         if answer is None:
             return "oops, sorry"
 


### PR DESCRIPTION
Refactores ask_yesno_question to ask a freeform question and parse the answer, as opposed to having it's own functionality. This allows us to remove pending_confirmations, do_yes, do_no. It now allows for people to cancel, which returns None. This might break some flows so we can reconsider that, but I think it's good to allow people to say "actually no, I want out of here, not yes not no"

also now accepts answers that are not just "yes" and "no" like "y" "n" "yeah" etc.

Hopefully removed all the obsoleted codepaths, but please let me know if I missed anything.