### PR TITLE
Os/emailvalidation

### DIFF
--- a/forest/autosave.py
+++ b/forest/autosave.py
@@ -79,10 +79,7 @@ async def start_memfs_monitor(app: web.Application) -> None:
         while True:
             queue_item = await queue.coro_get()
             # iff fsync triggered by signal-cli
-            if (
-                queue_item[0:2] == ["->", "fsync"]
-                and queue_item[5][0] == utils.ROOT_DIR + "/signal-cli"
-            ):
+            if queue_item[0:2] == ["->", "fsync"] and "-cli" in queue_item[5][0]:
                 # /+14703226669
                 # file_to_sync = queue_item[2]
                 # 14703226669

--- a/forest/core.py
+++ b/forest/core.py
@@ -1515,30 +1515,29 @@ class QuestionBot(PayBot):
     async def ask_email_question(
         self,
         recipient: str,
-        question_text: Optional[str] = "Please enter your email address",
-        require_first_device: bool = False,
+        question_text: str = "Please enter your email address",
     ) -> Optional[str]:
         """Prompts the user to enter an email address, and validates with a very long regular expression"""
 
         # ----SETUP----
         # ask for the email address as a freeform question instead of doing it ourselves
         answer = await self.ask_freeform_question(
-            recipient, question_text, require_first_device
+            recipient, question_text
         )
 
         # ----VALIDATE---- 
         # if answer contains a valid email address, add it to maybe_email
-        maybe_email = re.search(
+        maybe_match = re.search(
             r"""(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""",
             answer,
         )
         # maybe_email is a re.match object, which returns only if there is a match.
-        if maybe_email:
-            maybe_email = maybe_email.group(0)
+        if maybe_match:
+            email = maybe_match.group(0) 
         
         # ----INVALID?----
         # If we have an answer, but no matched email
-        if answer and not maybe_email:
+        if answer and not maybe_match:
             # return none and exit if user types cancel, stop, exit, etc...
             if answer.lower() in self.TERMINAL_ANSWERS:
                 return None
@@ -1552,11 +1551,10 @@ class QuestionBot(PayBot):
 
             return await self.ask_email_question(
                 recipient,
-                question_text,
-                require_first_device,
+                question_text
             )
-        # ----RETURN----
-        return maybe_email
+
+        return email 
 
     async def do_challenge(self, msg: Message) -> Response:
         """Challenges a user to do a simple math problem,

--- a/forest/core.py
+++ b/forest/core.py
@@ -1521,11 +1521,9 @@ class QuestionBot(PayBot):
 
         # ----SETUP----
         # ask for the email address as a freeform question instead of doing it ourselves
-        answer = await self.ask_freeform_question(
-            recipient, question_text
-        )
+        answer = await self.ask_freeform_question(recipient, question_text)
 
-        # ----VALIDATE---- 
+        # ----VALIDATE----
         # if answer contains a valid email address, add it to maybe_email
         maybe_match = re.search(
             r"""(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""",
@@ -1533,8 +1531,8 @@ class QuestionBot(PayBot):
         )
         # maybe_email is a re.match object, which returns only if there is a match.
         if maybe_match:
-            email = maybe_match.group(0) 
-        
+            email = maybe_match.group(0)
+
         # ----INVALID?----
         # If we have an answer, but no matched email
         if answer and not maybe_match:
@@ -1549,12 +1547,9 @@ class QuestionBot(PayBot):
                     "Please reply with a valid email address \n \n" + question_text
                 )
 
-            return await self.ask_email_question(
-                recipient,
-                question_text
-            )
+            return await self.ask_email_question(recipient, question_text)
 
-        return email 
+        return email
 
     async def do_challenge(self, msg: Message) -> Response:
         """Challenges a user to do a simple math problem,

--- a/forest/core.py
+++ b/forest/core.py
@@ -1544,7 +1544,7 @@ class QuestionBot(PayBot):
             # if the answer is not a valid email address, ask the question again, but don't let it add "Please reply" forever
             if "Please reply" not in question_text:
                 question_text = (
-                    "Please reply with a valid email address \n \n" + question_text
+                    "Please reply with a valid email address\n\n" + question_text
                 )
 
             return await self.ask_email_question(recipient, question_text)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -168,46 +168,23 @@ async def test_questions(bot) -> None:
 @pytest.mark.asyncio
 async def test_email_questions(bot) -> None:
     # normal email
+    answer = asyncio.create_task(bot.ask_email_question(USER_NUMBER))
+    await bot.send_input("example@example.com")
+    assert await answer == "example@example.com"
 
-    for test in [
-        "email@example.com",
-        "firstname.lastname@example.com",
-        "email@subdomain.example.com",
-        "firstname+lastname@example.com",
-        "email@123.123.123.123",
-        "email@[123.123.123.123]",
-        '"email"@example.com',
-        "1234567890@example.com",
-        "email@example-one.com",
-        "_______@example.com",
-        "email@example.name",
-        "email@example.museum",
-        "email@example.co.jp",
-        "firstname-lastname@example.com",
-        "Joe Smith <email@example.com>",
-        "email@example.com (Joe Smith)",
-    ]:
-        answer = asyncio.create_task(bot.ask_email_question(USER_NUMBER))
-        await bot.send_input(test)
-        assert await answer == test
+    # email with special character
+    answer = asyncio.create_task(bot.ask_email_question(USER_NUMBER))
+    await bot.send_input("exam+ple@example.com")
+    assert await answer == "exam+ple@example.com"
 
-    for test in [
-        "plainaddress",
-        "#@%^%#$@#$@#.com",
-        "@example.com",
-        "email.example.com",
-        "email@example@example.com",
-        ".email@example.com",
-        "email.@example.com",
-        "email..email@example.com",
-        "あいうえお@example.com",
-        "email@example",
-        "email@-example.com",
-        "email@example.web",
-        "email@111.222.333.44444",
-        "email@example..com",
-        "Abc..123@example.com",
-    ]:
-        answer = asyncio.create_task(bot.ask_email_question(USER_NUMBER))
-        await bot.send_input(test)
-        assert (await answer).startswith("Please reply with a valid email address")
+    # email with superfluous bits
+    answer = asyncio.create_task(bot.ask_email_question(USER_NUMBER))
+    await bot.send_input(
+        "hello my email is example@example.com and you can call me example"
+    )
+    assert await answer == "example@example.com"
+
+    # invalid email
+    answer = asyncio.create_task(bot.ask_email_question(USER_NUMBER))
+    await bot.send_input("random garbage")
+    assert (await answer).startswith("Please reply with a valid email address")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -163,3 +163,51 @@ async def test_questions(bot) -> None:
     t = asyncio.create_task(bot.ask_yesno_question(USER_NUMBER, "Do you like faeries?"))
     await bot.send_input("yes")
     assert await t == True
+
+
+@pytest.mark.asyncio
+async def test_email_questions(bot) -> None:
+    # normal email
+
+    for test in [
+        "email@example.com",
+        "firstname.lastname@example.com",
+        "email@subdomain.example.com",
+        "firstname+lastname@example.com",
+        "email@123.123.123.123",
+        "email@[123.123.123.123]",
+        '"email"@example.com',
+        "1234567890@example.com",
+        "email@example-one.com",
+        "_______@example.com",
+        "email@example.name",
+        "email@example.museum",
+        "email@example.co.jp",
+        "firstname-lastname@example.com",
+        "Joe Smith <email@example.com>",
+        "email@example.com (Joe Smith)",
+    ]:
+        answer = asyncio.create_task(bot.ask_email_question(USER_NUMBER))
+        await bot.send_input(test)
+        assert await answer == test
+
+    for test in [
+        "plainaddress",
+        "#@%^%#$@#$@#.com",
+        "@example.com",
+        "email.example.com",
+        "email@example@example.com",
+        ".email@example.com",
+        "email.@example.com",
+        "email..email@example.com",
+        "あいうえお@example.com",
+        "email@example",
+        "email@-example.com",
+        "email@example.web",
+        "email@111.222.333.44444",
+        "email@example..com",
+        "Abc..123@example.com",
+    ]:
+        answer = asyncio.create_task(bot.ask_email_question(USER_NUMBER))
+        await bot.send_input(test)
+        assert (await answer).startswith("Please reply with a valid email address")

--- a/tests/testbots/test_questions_bot.py
+++ b/tests/testbots/test_questions_bot.py
@@ -141,17 +141,13 @@ class TestBot(QuestionBot):
             return address
         return "oops, sorry"
 
-    async def do_test_email_question(
-        self, message: Message
-    ) -> Response:
+    async def do_test_email_question(self, message: Message) -> Response:
 
         email = await self.ask_email_question(message.source)
 
         if email:
             return email
         return "oops, sorry"
-
-    
 
 
 if __name__ == "__main__":

--- a/tests/testbots/test_questions_bot.py
+++ b/tests/testbots/test_questions_bot.py
@@ -141,6 +141,18 @@ class TestBot(QuestionBot):
             return address
         return "oops, sorry"
 
+    async def do_test_email_question(
+        self, message: Message
+    ) -> Response:
+
+        email = await self.ask_email_question(message.source)
+
+        if email:
+            return email
+        return "oops, sorry"
+
+    
+
 
 if __name__ == "__main__":
     run_bot(TestBot)


### PR DESCRIPTION
Added a function to do email validation in questionbot, using ask_freeform_question as a base. Tried to distill the format into something repeatable and structured. Also added a test. There's potential to abstract this out, to make a function like ask_specific_question that takes question_text and a validator function and the re-prompt if invalid, and generates a new question type.