### PR TITLE
Implement Safe Mode for Imogen in which she autoleaves unauthorised groups she's added to.

### DIFF
--- a/forest/core.py
+++ b/forest/core.py
@@ -31,7 +31,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import (
     Any,
-    Awaitable,
     Callable,
     Coroutine,
     Mapping,

--- a/forest/core.py
+++ b/forest/core.py
@@ -62,7 +62,7 @@ except ImportError:
 
 JSON = dict[str, Any]
 Response = Union[str, list, dict[str, str], None]
-AsyncFunc = Callable[..., Awaitable]
+AsyncFunc = Callable[..., Coroutine[Any, Any, Any]]
 Command = Callable[["Bot", Message], Coroutine[Any, Any, Response]]
 
 roundtrip_histogram = Histogram("roundtrip_h", "Roundtrip message response time")

--- a/forest/pdict.py
+++ b/forest/pdict.py
@@ -152,7 +152,7 @@ class PersistDict(dict):
             return val
 
         # creates a new event loop on a separate thread, invokes async_get function, returns result
-        result = self.thread_pool.submit(asyncio.run, async_get()).result()
+        result = self.thread_pool.submit(asyncio.run, async_get()).result()  # type: ignore
         dict_ = {}
         if isinstance(result, str) and result:
             dict_ = json.loads(result)
@@ -171,7 +171,7 @@ class PersistDict(dict):
             await client.conn.close()
             return val
 
-        return self.thread_pool.submit(asyncio.run, async_push()).result()
+        return self.thread_pool.submit(asyncio.run, async_push()).result()  # type: ignore
 
     def __setitem__(self, key: str, value: Union[float, str]) -> None:
         super().__setitem__(key, value)

--- a/forest/pghelp.py
+++ b/forest/pghelp.py
@@ -86,7 +86,7 @@ class SimpleInterface:
     @asynccontextmanager
     async def get_connection(self) -> AsyncGenerator:
         if not pool.pool:
-            pool.connect(self.database, "simple interface")
+            await pool.connect(self.database, "simple interface")
         assert pool.pool
         async with pool.acquire() as conn:
             logging.info("connection acquired")

--- a/hotline/hotline.py
+++ b/hotline/hotline.py
@@ -623,7 +623,7 @@ class ClanGat(TalkBack):
                     "What phrase should be returned when the easter egg is revealed?",
                 )
             if maybe_old_message:
-                self.send_message(msg.uuid, f"replacing: {maybe_old_message}")
+                await self.send_message(msg.uuid, f"replacing: {maybe_old_message}")
                 await self.easter_eggs.set(
                     param,
                     f"{value} - updated by {await self.get_displayname(msg.uuid)}",

--- a/imogen/imogen.py
+++ b/imogen/imogen.py
@@ -208,7 +208,7 @@ auto_messages = [
 class Imogen(GelatoBot):
     # pylint: disable=too-many-public-methods, no-self-use
     def __init__(self, bot_number: Optional[str] = None) -> None:
-        self.group_whitelist: aPersistDict[str] = aPersistDict("group_whitelist")
+        self.group_whitelist: aPersistDict[bool] = aPersistDict("group_whitelist")
         super().__init__(bot_number)
 
     async def start_process(self) -> None:

--- a/imogen/imogen.py
+++ b/imogen/imogen.py
@@ -259,22 +259,22 @@ class Imogen(GelatoBot):
 
     do_gg = do_get_group
 
+    # wishlist: get group ids for user
+
     @requires_admin
     async def do_whitelist_group(self, msg: Message) -> Response:
         """Adds a bot to a group and adds that group to the bot's whitelist"""
-        if msg.arg1:
-            await self.group_whitelist.set(msg.arg1, True)
-            return (
-                f'Succesfully added group: "{msg.arg1}" to whitelist. Invite me again.'
-            )
-
+        if msg.text:
+            for group in msg.text.split(","):
+                # ideally check if it's a group
+                await self.group_whitelist.set(group, True)
+            return f'Succesfully added group(s): "{msg.text}" to whitelist. Invite me again.'
         return "You must provide a group ID."
 
     @requires_admin
-    async def do_get_group_whitelist(self, msg: Message) -> Response:
+    async def do_get_group_whitelist(self, _: Message) -> Response:
         """Returns the list of groups this bot is allowed to be in whilst running in safe mode"""
         group_list = await self.group_whitelist.keys()
-
         return "\n".join(group_list)
 
     @requires_admin
@@ -723,7 +723,7 @@ class Imogen(GelatoBot):
         deets = " (started a new worker)" if worker_created else ""
         return f"you are #{result['queue_length']} in the diffusion line{deets}"
 
-    def make_prefix(prefix: str) -> Callable:  # type: ignore  # pylint: disable=no-self-argument
+    def make_prefix(prefix: str, *_) -> Callable:  # type: ignore  # pylint: disable=no-self-argument
         async def wrapped(self: "Imogen", msg: Message) -> Response:
             if msg.group and msg.group == utils.get_secret("ADMIN_GROUP"):
                 return None
@@ -741,7 +741,7 @@ class Imogen(GelatoBot):
     do_synthwave = make_prefix("synthwave")
     del make_prefix  # shouldn't be used after class definition is over
 
-    def single_response(response: str) -> Callable:  # type: ignore # pylint: disable=no-self-argument
+    def single_response(response: str, *_) -> Callable:  # type: ignore # pylint: disable=no-self-argument
         async def wrapped(self: "Imogen", msg: Message) -> Response:
             del self, msg  # shush pylint
             return response

--- a/imogen/imogen.py
+++ b/imogen/imogen.py
@@ -266,11 +266,7 @@ class Imogen(GelatoBot):
         await self.admin(msg.group)
         return None
 
-    @requires_admin
-    async def do_gg(self, msg: Message) -> None:
-        """like get group but more discreet"""
-        await self.do_get_group(msg)
-        return None
+    do_gg = do_get_group
 
     @requires_admin
     async def do_whitelist_group(self, msg: Message) -> Response:

--- a/imogen/imogen.py
+++ b/imogen/imogen.py
@@ -219,11 +219,31 @@ class Imogen(GelatoBot):
         # }
 
     ban = ["+15795090727", "+13068051597"]
+    group_whitelist : list [str]= []
 
     async def handle_message(self, message: Message) -> Response:
         if message.source in self.ban or message.uuid in self.ban:
             return None
+        
+        if utils.get_secret("SAFE_MODE"):
+            if message.group and message.group not in self.group_whitelist:
+                
+                ## leave group
+                self.admin(f"found myself running in a group I don't recognise. Leaving the group but if you'd like to add me use add_group {msg.group} to both add me to the group and add the group to the group whitelist")
+                pass
+
         return await super().handle_message(message)
+
+    @requires_admin
+    async def do_get_group(self, msg:Message) -> None:
+        await self.admin(msg.group)
+        return None
+
+    @requires_admin
+    async def do_gg(self, msg:Message) -> None:
+        """
+        await self.do_get_group(msg)
+        return None
 
     async def handle_reaction(self, msg: Message) -> Response:
         await super().handle_reaction(msg)

--- a/imogen/imogen.py
+++ b/imogen/imogen.py
@@ -208,9 +208,9 @@ auto_messages = [
 class Imogen(GelatoBot):
     # pylint: disable=too-many-public-methods, no-self-use
     def __init__(self, bot_number: Optional[str] = None) -> None:
-        self.group_whitelist : aPersistDict[str] = aPersistDict("group_whitelist")
+        self.group_whitelist: aPersistDict[str] = aPersistDict("group_whitelist")
         super().__init__(bot_number)
-        
+
     async def start_process(self) -> None:
         self.queue = pghelp.PGInterface(
             query_strings=QueueExpressions,
@@ -227,7 +227,6 @@ class Imogen(GelatoBot):
         # }
 
     ban = ["+15795090727", "+13068051597"]
-    
 
     async def handle_message(self, message: Message) -> Response:
         if message.source in self.ban or message.uuid in self.ban:
@@ -272,22 +271,20 @@ class Imogen(GelatoBot):
         return "You must provide a group ID."
 
     @requires_admin
-    async def do_get_group_whitelist(self, msg:Message) -> Response:
+    async def do_get_group_whitelist(self, msg: Message) -> Response:
         """Returns the list of groups this bot is allowed to be in whilst running in safe mode"""
         group_list = await self.group_whitelist.keys()
-        
+
         return "\n".join(group_list)
-    
+
     @requires_admin
-    async def do_unwhitelist_group(self, msg:Message) -> Response:
+    async def do_unwhitelist_group(self, msg: Message) -> Response:
         """Remove arg1 from whitelisted group list, if no arg1."""
         if msg.arg1 and msg.arg1 in await self.group_whitelist.keys():
             await self.group_whitelist.remove(msg.arg1)
             return f"group: {msg.arg1} removed from whitelist"
 
         return "You must provide a group id to use this command."
-        
-
 
     async def handle_reaction(self, msg: Message) -> Response:
         await super().handle_reaction(msg)


### PR DESCRIPTION
Currently this leaves immediately upon adding on signal-cli or at any point where imogen receives a message in a group that's not whitelisted. 

uses SAFE_MODE flag

would be nice to make the whitelist a pdict or something so you can add more groups persistently on the fly. could also do some different postgres magic for it.